### PR TITLE
Allow external test files.

### DIFF
--- a/gunit/main.go
+++ b/gunit/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"go/build"
 	"io/ioutil"
 	"log"
@@ -58,7 +59,7 @@ func parseFixtures(pkg *build.Package) []*parse.Fixture {
 	fixtures := []*parse.Fixture{}
 	badFixtures := new(bytes.Buffer)
 
-	for _, filename := range pkg.TestGoFiles {
+	for _, filename := range append(pkg.TestGoFiles, pkg.XTestGoFiles...) {
 		if filename == generate.GeneratedFilename {
 			continue
 		}
@@ -95,7 +96,12 @@ func generateTestFileContents(pkg *build.Package, fixtures []*parse.Fixture) []b
 	code, err := generate.CodeListing(pkg.Dir)
 	fatal(err)
 
-	generated, err := generate.TestFile(pkg.Name, fixtures, checksum, code)
+	importName := pkg.Name
+	if len(pkg.XTestGoFiles) > 0 {
+		importName = fmt.Sprintf("%s_test", importName)
+	}
+
+	generated, err := generate.TestFile(importName, fixtures, checksum, code)
 	fatal(err)
 
 	return generated

--- a/test_pkg_examples/example.go
+++ b/test_pkg_examples/example.go
@@ -1,0 +1,1 @@
+package pkg_example

--- a/test_pkg_examples/examples_test.go
+++ b/test_pkg_examples/examples_test.go
@@ -1,0 +1,37 @@
+package pkg_example_test
+
+//go:generate gunit -suffix 1
+
+import (
+	"github.com/smartystreets/assertions/should"
+	"github.com/smartystreets/gunit"
+)
+
+type ExampleFixture struct {
+	*gunit.Fixture // Required: Embedding this type is what makes the magic happen.
+
+	// Declare useful state here (probably the stuff being testing, any fakes, etc...).
+}
+
+func (self *ExampleFixture) SetupStuff() {
+	// This optional method will be executed before each "Test"
+	// method becuase it starts with "Setup".
+}
+func (self *ExampleFixture) TeardownStuff() {
+	// This optional method will be executed after each "Test"
+	// method (because it starts with "Teardown"), even if the test method panics.
+}
+
+// This is an actual test case:
+func (self *ExampleFixture) TestWithAssertions() {
+	// Here's how to use the functions from the `should`
+	// package at github.com/smartystreets/assertions/should
+	// to perform assertions:
+	self.So(42, should.Equal, 42)
+	self.So("Hello, World!", should.ContainSubstring, "World")
+	self.Ok(1 == 1, "One should equal one")
+}
+
+func (self *ExampleFixture) SkipTestWithNothing() {
+	// Because this method's name starts with 'Skip', this will be skipped in the generated code.
+}

--- a/test_pkg_examples/examples_test.go
+++ b/test_pkg_examples/examples_test.go
@@ -1,6 +1,6 @@
 package pkg_example_test
 
-//go:generate gunit -suffix 1
+//go:generate gunit
 
 import (
 	"github.com/smartystreets/assertions/should"


### PR DESCRIPTION
Make external test (e.g.  `*_test` packages) work.