### PR TITLE
Fix gunit when GOPATH has multiple directories

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 Copyright (c) 2015 SmartyStreets
+Copyright (c) 2016 Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gunit/main.go
+++ b/gunit/main.go
@@ -51,7 +51,17 @@ func resolveImportPath() string {
 	working, err := os.Getwd()
 	fatal(err)
 
-	return strings.Replace(working, path.Join(gopath, "src")+"/", "", 1)
+	dirs := strings.Split(gopath, ":")
+	for _, dir := range dirs {
+		srcDir := path.Join(dir, "src") + "/"
+		packageName := strings.Replace(working, srcDir, "", 1)
+		if packageName != working {
+			return packageName
+		}
+	}
+
+	logger.Fatal("Cannot determine package name from current directory; must run gunit from within a package")
+	panic("Not reachable")
 }
 
 func parseFixtures(pkg *build.Package) []*parse.Fixture {


### PR DESCRIPTION
The resolveImportPath function attempts to determine the package name
based on the current directory and the GOPATH setting.  However, it
previously assumed that GOPATH had only a single component, while it is
valid for GOPATH to hold multiple directories separated by a colon.

Fix this by making resolveImportPath attempt to replace all components
of GOPATH until a match is found and, if no match is found, fail with a
descriptive error message.  Before this, the only message the user would
get was "cannot import absolute path" which does not point at the
problem.