### PR TITLE
Print <file:line> for failed, skipped and/or verbose tests

### DIFF
--- a/failure_report.go
+++ b/failure_report.go
@@ -15,11 +15,10 @@ type failureReport struct {
 	Fixture  string
 	Package  string
 	Failure  string
-	FileLine string
 }
 
-func newFailureReport(failure, fileLine string) string {
-	report := &failureReport{Failure: failure, FileLine: fileLine}
+func newFailureReport(failure string) string {
+	report := &failureReport{Failure: failure}
 	report.ScanStack()
 	return report.String()
 }
@@ -61,7 +60,6 @@ func (this *failureReport) ParseTestName(name string) {
 
 func (this failureReport) String() string {
 	buffer := new(bytes.Buffer)
-	fmt.Fprintf(buffer, "(@)       %s\n",  this.FileLine)
 	for i, stack := range this.Stack {
 		fmt.Fprintf(buffer, "(%d):      %s\n", len(this.Stack)-i-1, stack)
 	}

--- a/fixture.go
+++ b/fixture.go
@@ -25,13 +25,14 @@ import (
 // on Fixture.So and the rich set of should-style assertions provided at
 // github.com/smartystreets/assertions/should
 type Fixture struct {
-	t       testingT
-	log     *bytes.Buffer
-	verbose bool
+	t        testingT
+	log      *bytes.Buffer
+	verbose  bool
+	fileLine string
 }
 
-func newFixture(t testingT, verbose bool) *Fixture {
-	return &Fixture{t: t, verbose: verbose, log: &bytes.Buffer{}}
+func newFixture(t testingT, verbose bool, fileLine string) *Fixture {
+	return &Fixture{t: t, verbose: verbose, log: &bytes.Buffer{}, fileLine: fileLine}
 }
 
 // So is a convenience method for reporting assertion failure messages,
@@ -41,7 +42,6 @@ func (this *Fixture) So(actual interface{}, assert assertion, expected ...interf
 	failure := assert(actual, expected...)
 	failed := len(failure) > 0
 	if failed {
-		this.t.Fail()
 		this.fail(failure)
 	}
 	return !failed
@@ -81,12 +81,12 @@ func (this *Fixture) Println(a ...interface{})               { fmt.Fprintln(this
 
 // Write implements io.Writer. There are rare times when this is convenient (debugging via `log.SetOutput(fixture)`).
 func (this *Fixture) Write(p []byte) (int, error) { return this.log.Write(p) }
-func (this *Fixture) Failed() bool { return this.t.Failed() }
-func (this *Fixture) Name() string { return this.t.Name() }
+func (this *Fixture) Failed() bool                { return this.t.Failed() }
+func (this *Fixture) Name() string                { return this.t.Name() }
 
 func (this *Fixture) fail(failure string) {
 	this.t.Fail()
-	this.Print(newFailureReport(failure))
+	this.Print(newFailureReport(failure, this.fileLine))
 }
 
 func (this *Fixture) finalize() {

--- a/fixture.go
+++ b/fixture.go
@@ -94,6 +94,8 @@ func (this *Fixture) finalize() {
 		this.recoverPanic(r)
 	}
 
+	this.t.Log("\n" + this.fileLine)
+
 	if this.t.Failed() || (this.verbose && this.log.Len() > 0) {
 		this.t.Log("\n" + strings.TrimSpace(this.log.String()) + "\n")
 	}

--- a/fixture.go
+++ b/fixture.go
@@ -25,14 +25,13 @@ import (
 // on Fixture.So and the rich set of should-style assertions provided at
 // github.com/smartystreets/assertions/should
 type Fixture struct {
-	t        testingT
-	log      *bytes.Buffer
-	verbose  bool
-	fileLine string
+	t       testingT
+	log     *bytes.Buffer
+	verbose bool
 }
 
-func newFixture(t testingT, verbose bool, fileLine string) *Fixture {
-	return &Fixture{t: t, verbose: verbose, log: &bytes.Buffer{}, fileLine: fileLine}
+func newFixture(t testingT, verbose bool) *Fixture {
+	return &Fixture{t: t, verbose: verbose, log: &bytes.Buffer{}}
 }
 
 // So is a convenience method for reporting assertion failure messages,
@@ -86,15 +85,13 @@ func (this *Fixture) Name() string                { return this.t.Name() }
 
 func (this *Fixture) fail(failure string) {
 	this.t.Fail()
-	this.Print(newFailureReport(failure, this.fileLine))
+	this.Print(newFailureReport(failure))
 }
 
 func (this *Fixture) finalize() {
 	if r := recover(); r != nil {
 		this.recoverPanic(r)
 	}
-
-	this.t.Log("\n" + this.fileLine)
 
 	if this.t.Failed() || (this.verbose && this.log.Len() > 0) {
 		this.t.Log("\n" + strings.TrimSpace(this.log.String()) + "\n")

--- a/fixture_runner.go
+++ b/fixture_runner.go
@@ -3,15 +3,18 @@ package gunit
 import (
 	"reflect"
 	"testing"
+
+	"github.com/smartystreets/gunit/scan"
 )
 
-func newFixtureRunner(fixture interface{}, t *testing.T, parallel bool) *fixtureRunner {
+func newFixtureRunner(fixture interface{}, t *testing.T, parallel bool, positions scan.TestCasePositions) *fixtureRunner {
 	return &fixtureRunner{
 		parallel:    parallel,
 		setup:       -1,
 		teardown:    -1,
 		outerT:      t,
 		fixtureType: reflect.ValueOf(fixture).Type(),
+		positions:   positions,
 	}
 }
 
@@ -19,11 +22,12 @@ type fixtureRunner struct {
 	outerT      *testing.T
 	fixtureType reflect.Type
 
-	parallel bool
-	setup    int
-	teardown int
-	focus    []*testCase
-	tests    []*testCase
+	parallel  bool
+	setup     int
+	teardown  int
+	focus     []*testCase
+	tests     []*testCase
+	positions scan.TestCasePositions
 }
 
 func (this *fixtureRunner) ScanFixtureForTestCases() {
@@ -40,9 +44,9 @@ func (this *fixtureRunner) scanFixtureMethod(methodIndex int, method fixtureMeth
 	case method.isTeardown:
 		this.teardown = methodIndex
 	case method.isFocusTest:
-		this.focus = append(this.focus, newTestCase(methodIndex, method, this.parallel))
+		this.focus = append(this.focus, newTestCase(methodIndex, method, this.parallel, this.positions))
 	case method.isTest:
-		this.tests = append(this.tests, newTestCase(methodIndex, method, this.parallel))
+		this.tests = append(this.tests, newTestCase(methodIndex, method, this.parallel, this.positions))
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -2,7 +2,10 @@ package gunit
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
+
+	"github.com/smartystreets/gunit/scan"
 )
 
 // Run receives an instance of a struct that embeds *Fixture.
@@ -22,7 +25,11 @@ func RunSequential(fixture interface{}, t *testing.T) {
 
 func run(fixture interface{}, t *testing.T, parallel bool) {
 	ensureEmbeddedFixture(fixture, t)
-	runner := newFixtureRunner(fixture, t, parallel)
+
+	_, filename, _, _ := runtime.Caller(2)
+	positions := scan.LocateTestCases(filename)
+
+	runner := newFixtureRunner(fixture, t, parallel, positions)
 	runner.ScanFixtureForTestCases()
 	runner.RunTestCases()
 }

--- a/scan/0_parser.go
+++ b/scan/0_parser.go
@@ -1,0 +1,40 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+//////////////////////////////////////////////////////////////////////////////
+
+func scanForFixtures(code string) ([]*fixtureInfo, error) {
+	fileset := token.NewFileSet()
+	file, err := parser.ParseFile(fileset, "", code, 0)
+	if err != nil {
+		return nil, err
+	}
+	// ast.Print(fileset, file) // helps with debugging...
+	return findAndListFixtures(file)
+}
+
+func findAndListFixtures(file *ast.File) ([]*fixtureInfo, error) {
+	collection := newFixtureCollector().Collect(file)
+	collection = newFixtureMethodFinder(collection).Find(file)
+	return listFixtures(collection)
+}
+
+func listFixtures(collection map[string]*fixtureInfo) ([]*fixtureInfo, error) {
+	var fixtures []*fixtureInfo
+	errorMessage := new(bytes.Buffer)
+
+	for _, fixture := range collection {
+		fixtures = append(fixtures, fixture)
+	}
+	if errorMessage.Len() > 0 {
+		return nil, errors.New(errorMessage.String())
+	}
+	return fixtures, nil
+}

--- a/scan/1_fixture_collector.go
+++ b/scan/1_fixture_collector.go
@@ -1,0 +1,40 @@
+package scan
+
+import "go/ast"
+
+type fixtureCollector struct {
+	candidates map[string]*fixtureInfo
+	fixtures   map[string]*fixtureInfo
+}
+
+func newFixtureCollector() *fixtureCollector {
+	return &fixtureCollector{
+		candidates: make(map[string]*fixtureInfo),
+		fixtures:   make(map[string]*fixtureInfo),
+	}
+}
+
+func (this *fixtureCollector) Collect(file *ast.File) map[string]*fixtureInfo {
+	ast.Walk(this, file) // Calls this.Visit(...) recursively which populates this.fixtures
+	return this.fixtures
+}
+
+func (this *fixtureCollector) Visit(node ast.Node) ast.Visitor {
+	switch t := node.(type) {
+	case *ast.TypeSpec:
+		name := t.Name.Name
+		this.candidates[name] = &fixtureInfo{StructName: name}
+		return &fixtureValidator{Parent: this, FixtureName: name}
+	default:
+		return this
+	}
+}
+
+func (this *fixtureCollector) Validate(fixture string) {
+	this.fixtures[fixture] = this.candidates[fixture]
+	delete(this.candidates, fixture)
+}
+
+func (this *fixtureCollector) Invalidate(fixture string) {
+	this.Validate(fixture)
+}

--- a/scan/2_fixture_validator.go
+++ b/scan/2_fixture_validator.go
@@ -1,0 +1,31 @@
+package scan
+
+import "go/ast"
+
+type fixtureValidator struct {
+	Parent      *fixtureCollector
+	FixtureName string
+}
+
+func (this *fixtureValidator) Visit(node ast.Node) ast.Visitor {
+	// We start at a TypeSpec and look for an embedded pointer field: `*gunit.Fixture`.
+	field, isField := node.(*ast.Field)
+	if !isField {
+		return this
+	}
+	pointer, isPointer := field.Type.(*ast.StarExpr)
+	if !isPointer {
+		return this
+	}
+
+	selector, isSelector := pointer.X.(*ast.SelectorExpr)
+	if !isSelector {
+		return this
+	}
+	gunit, isGunit := selector.X.(*ast.Ident)
+	if selector.Sel.Name != "Fixture" || !isGunit || gunit.Name != "gunit" {
+		return this
+	}
+	this.Parent.Validate(this.FixtureName)
+	return nil
+}

--- a/scan/3_method_finder.go
+++ b/scan/3_method_finder.go
@@ -1,0 +1,77 @@
+package scan
+
+import (
+	"go/ast"
+	"strings"
+)
+
+type fixtureMethodFinder struct {
+	fixtures map[string]*fixtureInfo
+}
+
+func newFixtureMethodFinder(fixtures map[string]*fixtureInfo) *fixtureMethodFinder {
+	return &fixtureMethodFinder{fixtures: fixtures}
+}
+
+func (this *fixtureMethodFinder) Find(file *ast.File) map[string]*fixtureInfo {
+	ast.Walk(this, file) // Calls this.Visit(...) recursively.
+	return this.fixtures
+}
+
+func (this *fixtureMethodFinder) Visit(node ast.Node) ast.Visitor {
+	function, isFunction := node.(*ast.FuncDecl)
+	if !isFunction {
+		return this
+	}
+
+	if function.Recv.NumFields() == 0 {
+		return nil
+	}
+
+	receiver, isPointer := function.Recv.List[0].Type.(*ast.StarExpr)
+	if !isPointer {
+		return this
+	}
+
+	fixtureName := receiver.X.(*ast.Ident).Name
+	fixture, functionMatchesFixture := this.fixtures[fixtureName]
+	if !functionMatchesFixture {
+		return nil
+	}
+
+	if !isExportedAndVoidAndNiladic(function) {
+		return this
+	}
+
+	this.attach(function, fixture)
+	return nil
+}
+
+func isExportedAndVoidAndNiladic(function *ast.FuncDecl) bool {
+	if isExported := function.Name.IsExported(); !isExported {
+		return false
+	}
+	if isNiladic := function.Type.Params.NumFields() == 0; !isNiladic {
+		return false
+	}
+	isVoid := function.Type.Results.NumFields() == 0
+	return isVoid
+}
+
+func (this *fixtureMethodFinder) attach(function *ast.FuncDecl, fixture *fixtureInfo) {
+	if IsTestCase(function.Name.Name) {
+		fixture.TestCases = append(fixture.TestCases, &testCaseInfo{
+			CharacterPosition: int(function.Pos()),
+			Name:              function.Name.Name,
+		})
+	}
+}
+
+func IsTestCase(name string) bool {
+	return strings.HasPrefix(name, "Test") ||
+		strings.HasPrefix(name, "LongTest") ||
+		strings.HasPrefix(name, "FocusTest") ||
+		strings.HasPrefix(name, "FocusLongTest") ||
+		strings.HasPrefix(name, "SkipTest") ||
+		strings.HasPrefix(name, "SkipLongTest")
+}

--- a/scan/fixture.go
+++ b/scan/fixture.go
@@ -1,0 +1,13 @@
+package scan
+
+type fixtureInfo struct {
+	Filename   string
+	StructName string
+	TestCases  []*testCaseInfo
+}
+
+type testCaseInfo struct {
+	CharacterPosition int
+	LineNumber        int
+	Name              string
+}

--- a/scan/parser_test.go
+++ b/scan/parser_test.go
@@ -1,0 +1,87 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+)
+
+//////////////////////////////////////////////////////////////////////////////
+
+func TestParseFileWithValidFixturesAndConstructs(t *testing.T) {
+	test := &FixtureParsingFixture{t: t, input: comprehensiveTestCode}
+	test.ParseFixtures()
+	test.AssertFixturesParsedAccuratelyAndCompletely()
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+type FixtureParsingFixture struct {
+	t *testing.T
+
+	input      string
+	readError  error
+	parseError error
+	fixtures   []*fixtureInfo
+}
+
+func (this *FixtureParsingFixture) ParseFixtures() {
+	this.fixtures, this.parseError = scanForFixtures(this.input)
+}
+
+func (this *FixtureParsingFixture) AssertFixturesParsedAccuratelyAndCompletely() {
+	this.assertFileWasReadWithoutError()
+	this.assertFileWasParsedWithoutError()
+	this.assertAllFixturesParsed()
+	this.assertParsedFixturesAreCorrect()
+}
+func (this *FixtureParsingFixture) assertFileWasReadWithoutError() {
+	if this.readError != nil {
+		this.t.Error("Problem: cound't read the input file:", this.readError)
+		this.t.FailNow()
+	}
+}
+func (this *FixtureParsingFixture) assertFileWasParsedWithoutError() {
+	if this.parseError != nil {
+		this.t.Error("Problem: unexpected parsing error: ", this.parseError)
+		this.t.FailNow()
+	}
+}
+func (this *FixtureParsingFixture) assertAllFixturesParsed() {
+	if len(this.fixtures) != len(expected) {
+		this.t.Logf("Problem: Got back the wrong number of fixtures. Expected: %d Got: %d", len(expected), len(this.fixtures))
+		this.t.FailNow()
+	}
+}
+func (this *FixtureParsingFixture) assertParsedFixturesAreCorrect() {
+	for x := 0; x < len(expected); x++ {
+		key := this.fixtures[x].StructName
+		if ok, message := assertions.So(this.fixtures[x], should.Resemble, expected[key]); !ok {
+			this.t.Errorf("Comparison failure for record: %d\n%s", x, message)
+		}
+	}
+}
+
+func (this *FixtureParsingFixture) AssertErrorWasReturned() {
+	if this.parseError == nil {
+		this.t.Error("Expected an error, but got nil instead")
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+var expected = map[string]*fixtureInfo{
+	"BowlingGameScoringTests": {
+		StructName: "BowlingGameScoringTests",
+		TestCases: []*testCaseInfo{
+			{CharacterPosition: 335, Name: "TestAfterAllGutterBallsTheScoreShouldBeZero",},
+			{CharacterPosition: 490, Name: "TestAfterAllOnesTheScoreShouldBeTwenty",},
+			{CharacterPosition: 641, Name: "SkipTestASpareDeservesABonus",},
+			{CharacterPosition: 718, Name: "LongTestPerfectGame",},
+			{CharacterPosition: 852, Name: "SkipLongTestPerfectGame",},
+		},
+	},
+}
+
+//////////////////////////////////////////////////////////////////////////////

--- a/scan/parser_test_inputs_test.go
+++ b/scan/parser_test_inputs_test.go
@@ -1,0 +1,162 @@
+package scan
+
+const comprehensiveTestCode = `package parse
+
+import (
+	"github.com/smartystreets/assertions/should"
+	"github.com/smartystreets/gunit"
+)
+
+type BowlingGameScoringTests struct {
+	*gunit.Fixture
+
+	game *Game
+}
+
+func (self *BowlingGameScoringTests) SetupTheGame() {
+	self.game = NewGame()
+}
+
+func (self *BowlingGameScoringTests) TeardownTheGame() {
+	self.game = nil
+}
+
+func (self *BowlingGameScoringTests) TestAfterAllGutterBallsTheScoreShouldBeZero() {
+	self.rollMany(20, 0)
+	self.So(self.game.Score(), should.Equal, 0)
+}
+
+func (self *BowlingGameScoringTests) TestAfterAllOnesTheScoreShouldBeTwenty() {
+	self.rollMany(20, 1)
+	self.So(self.game.Score(), should.Equal, 20)
+}
+
+func (self *BowlingGameScoringTests) SkipTestASpareDeservesABonus()      {}
+
+func (self *BowlingGameScoringTests) LongTestPerfectGame() {
+	self.rollMany(12, 10)
+	self.So(self.game.Score(), should.Equal, 300)
+}
+
+func (self *BowlingGameScoringTests) SkipLongTestPerfectGame() {
+	self.rollMany(12, 10)
+	self.So(self.game.Score(), should.Equal, 300)
+}
+
+func (self *BowlingGameScoringTests) rollMany(times, pins int) {
+	for x := 0; x < times; x++ {
+		self.game.Roll(pins)
+	}
+}
+func (self *BowlingGameScoringTests) rollSpare() {
+	self.game.Roll(5)
+	self.game.Roll(5)
+}
+func (self *BowlingGameScoringTests) rollStrike() {
+	self.game.Roll(10)
+}
+
+func (self *BowlingGameScoringTests) TestNotNiladic_ShouldNotBeCollected(a int) {
+	// This should not be collected (it's not niladic)
+}
+func (self *BowlingGameScoringTests) TestNotVoid_ShouldNOTBeCollected() int {
+	return -1
+	// This should not be collected (it's not void)
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+// Game contains the state of a bowling game.
+type Game struct {
+	rolls   []int
+	current int
+}
+
+// NewGame allocates and starts a new game of bowling.
+func NewGame() *Game {
+	game := new(Game)
+	game.rolls = make([]int, maxThrowsPerGame)
+	return game
+}
+
+// Roll rolls the ball and knocks down the number of pins specified by pins.
+func (self *Game) Roll(pins int) {
+	self.rolls[self.current] = pins
+	self.current++
+}
+
+// Score calculates and returns the player's current score.
+func (self *Game) Score() (sum int) {
+	for throw, frame := 0, 0; frame < framesPerGame; frame++ {
+		if self.isStrike(throw) {
+			sum += self.strikeBonusFor(throw)
+			throw += 1
+		} else if self.isSpare(throw) {
+			sum += self.spareBonusFor(throw)
+			throw += 2
+		} else {
+			sum += self.framePointsAt(throw)
+			throw += 2
+		}
+	}
+	return sum
+}
+
+// isStrike determines if a given throw is a strike or not. A strike is knocking
+// down all pins in one throw.
+func (self *Game) isStrike(throw int) bool {
+	return self.rolls[throw] == allPins
+}
+
+// strikeBonusFor calculates and returns the strike bonus for a throw.
+func (self *Game) strikeBonusFor(throw int) int {
+	return allPins + self.framePointsAt(throw+1)
+}
+
+// isSpare determines if a given frame is a spare or not. A spare is knocking
+// down all pins in one frame with two throws.
+func (self *Game) isSpare(throw int) bool {
+	return self.framePointsAt(throw) == allPins
+}
+
+// spareBonusFor calculates and returns the spare bonus for a throw.
+func (self *Game) spareBonusFor(throw int) int {
+	return allPins + self.rolls[throw+2]
+}
+
+// framePointsAt computes and returns the score in a frame specified by throw.
+func (self *Game) framePointsAt(throw int) int {
+	return self.rolls[throw] + self.rolls[throw+1]
+}
+
+const (
+	// allPins is the number of pins allocated per fresh throw.
+	allPins = 10
+
+	// framesPerGame is the number of frames per bowling game.
+	framesPerGame = 10
+
+	// maxThrowsPerGame is the maximum number of throws possible in a single game.
+	maxThrowsPerGame = 21
+)
+
+//////////////////////////////////////////////////////////////////////////////
+// These types shouldn't be parsed as fixtures:
+
+type TestFixtureWrongTestCase struct {
+	*blah.Fixture
+}
+type TestFixtureWrongPackage struct {
+	*gunit.Fixture2
+}
+
+type Hah interface {
+	Hi() string
+}
+
+type BlahFixture struct {
+	blah int
+}
+
+//////////////////////////////////////////////////////////////////////////////
+`

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -1,0 +1,49 @@
+package scan
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+type TestCasePositions map[string]string
+
+func LocateTestCases(filename string) TestCasePositions {
+	return gatherTestCaseLineNumbers(parseFixtures(filename))
+}
+
+func gatherTestCaseLineNumbers(fixtures []*fixtureInfo) TestCasePositions {
+	positions := make(TestCasePositions)
+	for _, fixture := range fixtures {
+		for _, test := range fixture.TestCases {
+			key := fmt.Sprintf("Test%s/%s", fixture.StructName, test.Name)
+			value := fmt.Sprintf("%s:%d", fixture.Filename, test.LineNumber)
+			positions[key] = value
+		}
+	}
+	return positions
+}
+
+func parseFixtures(filename string) (fixtures []*fixtureInfo) {
+	source, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil
+	}
+	batch, err := scanForFixtures(string(source))
+	if err != nil {
+		return nil
+	}
+	for _, fixture := range batch {
+		fixture.Filename = filename
+		fixtures = append(fixtures, fixture)
+		for _, test := range fixture.TestCases {
+			test.LineNumber = lineNumber(string(source), test.CharacterPosition)
+		}
+	}
+	return fixtures
+}
+
+func lineNumber(source string, position int) int {
+	source = source[:position+1]
+	return strings.Count(source, "\n") + 1
+}

--- a/test_case.go
+++ b/test_case.go
@@ -64,7 +64,8 @@ func (this *testCase) run(innerT *testing.T) {
 	this.runWithSetupAndTeardown()
 }
 func (this *testCase) initializeFixture(innerT *testing.T) {
-	this.innerFixture = newFixture(innerT, testing.Verbose(), this.positions[innerT.Name()])
+	innerT.Log("Test definition:\n" + this.positions[innerT.Name()])
+	this.innerFixture = newFixture(innerT, testing.Verbose())
 	this.outerFixture = reflect.New(this.outerFixtureType.Elem())
 	this.outerFixture.Elem().FieldByName("Fixture").Set(reflect.ValueOf(this.innerFixture))
 }

--- a/test_case.go
+++ b/test_case.go
@@ -3,6 +3,8 @@ package gunit
 import (
 	"reflect"
 	"testing"
+
+	"github.com/smartystreets/gunit/scan"
 )
 
 type testCase struct {
@@ -17,15 +19,17 @@ type testCase struct {
 	innerFixture     *Fixture
 	outerFixtureType reflect.Type
 	outerFixture     reflect.Value
+	positions        scan.TestCasePositions
 }
 
-func newTestCase(methodIndex int, method fixtureMethodInfo, parallel bool) *testCase {
+func newTestCase(methodIndex int, method fixtureMethodInfo, parallel bool, positions scan.TestCasePositions) *testCase {
 	return &testCase{
 		parallel:    parallel,
 		methodIndex: methodIndex,
 		description: method.name,
 		skipped:     method.isSkippedTest,
 		long:        method.isLongTest,
+		positions:   positions,
 	}
 }
 
@@ -37,17 +41,20 @@ func (this *testCase) Prepare(setup, teardown int, outerFixtureType reflect.Type
 
 func (this *testCase) Run(t *testing.T) {
 	if this.skipped {
-		t.Run(this.description, skip)
+		t.Run(this.description, this.skip)
 	} else if this.long && testing.Short() {
-		t.Run(this.description, skipLong)
+		t.Run(this.description, this.skipLong)
 	} else {
 		t.Run(this.description, this.run)
 	}
 }
 
-func skip(innerT *testing.T)     { innerT.Skip("Skipped test") }
-func skipLong(innerT *testing.T) { innerT.Skip("Skipped long-running test") }
-
+func (this *testCase) skip(innerT *testing.T) {
+	innerT.Skip("\n" + this.positions[innerT.Name()])
+}
+func (this *testCase) skipLong(innerT *testing.T) {
+	innerT.Skipf("Skipped long-running test:\n" + this.positions[innerT.Name()])
+}
 func (this *testCase) run(innerT *testing.T) {
 	if this.parallel {
 		innerT.Parallel()
@@ -57,7 +64,7 @@ func (this *testCase) run(innerT *testing.T) {
 	this.runWithSetupAndTeardown()
 }
 func (this *testCase) initializeFixture(innerT *testing.T) {
-	this.innerFixture = newFixture(innerT, testing.Verbose())
+	this.innerFixture = newFixture(innerT, testing.Verbose(), this.positions[innerT.Name()])
 	this.outerFixture = reflect.New(this.outerFixtureType.Elem())
 	this.outerFixture.Elem().FieldByName("Fixture").Set(reflect.ValueOf(this.innerFixture))
 }


### PR DESCRIPTION
- Resolves #11 (failures in setup/teardown)
- Resolves #15 (skipped tests)
- Helps with #12 (all tests in verbose mode--allows 1-click navigation from GoLand test runner console)