### PR TITLE
Fix missing ellipsis in args forwarded to printf-like function

### DIFF
--- a/fixture_test.go
+++ b/fixture_test.go
@@ -345,7 +345,7 @@ func (self *FakeTestingT) Fail()                   { self.failed = true }
 func (self *FakeTestingT) Failed() bool            { return self.failed }
 func (this *FakeTestingT) Fatalf(format string, args ...interface{}) {
 	this.Fail()
-	this.Log(fmt.Sprintf(format, args))
+	this.Log(fmt.Sprintf(format, args...))
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix the following test error with Go 1.12.2:

```testing: github.com/smartystreets/gunit
github.com/smartystreets/gunit
./fixture_test.go:350:11: missing ... in args forwarded to printf-like function
FAIL	github.com/smartystreets/gunit [build failed]```