### PR TITLE
Disallow execution of private fixtures (breaks stack trace printing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ func TestExampleFixture(t *testing.T) {
 	gunit.Run(new(ExampleFixture), t)
 }
 
+// Be sure that your fixture is exportable
+// otherwise you'll not be able to retrieve your fixture file:line report for errors
 type ExampleFixture struct {
 	*gunit.Fixture // Required: Embedding this type is what makes the magic happen.
 

--- a/runner.go
+++ b/runner.go
@@ -1,6 +1,7 @@
 package gunit
 
 import (
+	"fmt"
 	"reflect"
 	"runtime"
 	"testing"
@@ -25,6 +26,7 @@ func RunSequential(fixture interface{}, t *testing.T) {
 
 func run(fixture interface{}, t *testing.T, parallel bool) {
 	ensureEmbeddedFixture(fixture, t)
+	checkExportingFixture(fixture, t)
 
 	_, filename, _, _ := runtime.Caller(2)
 	positions := scan.LocateTestCases(filename)
@@ -42,6 +44,13 @@ func ensureEmbeddedFixture(fixture interface{}, t TestingT) {
 	}
 }
 
-type goodExample struct{ *Fixture }
+func checkExportingFixture(fixture interface{}, t TestingT) {
+	fixtureType := reflect.TypeOf(fixture)
+	if fixtureType.Name() == "" {
+		t.Log(fmt.Sprintf("Type (%v) is not exportable", fixtureType))
+	}
+}
 
-var embeddedGoodExample, _ = reflect.TypeOf(new(goodExample)).Elem().FieldByName("Fixture")
+type GoodExample struct{ *Fixture }
+
+var embeddedGoodExample, _ = reflect.TypeOf(new(GoodExample)).Elem().FieldByName("Fixture")

--- a/runner_test.go
+++ b/runner_test.go
@@ -157,3 +157,14 @@ func (this *RunnerFixtureWithOnlyOneFocus) FocusTest1() {
 
 /**************************************************************************/
 /**************************************************************************/
+
+func TestWarningOfPrivateFixture(t *testing.T) {
+	RunSequential(new(privateFixture), t)
+}
+
+type privateFixture struct{ *Fixture }
+
+func (this *privateFixture) Test1() {}
+
+/**************************************************************************/
+/**************************************************************************/


### PR DESCRIPTION
https://github.com/smartystreets/gunit/issues/15